### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that integrates with Chart-IMG API to generate TradingView chart visualizations using Server-Sent Events (SSE) for real-time updates.
 
+<a href="https://glama.ai/mcp/servers/@wubbyweb/MCPChartServer">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wubbyweb/MCPChartServer/badge" alt="Chart Server MCP server" />
+</a>
+
 ## Features
 
 - **Real-time Chart Generation**: Generate TradingView charts with live progress updates


### PR DESCRIPTION
This PR adds a badge for the [MCP Chart Server](https://glama.ai/mcp/servers/@wubbyweb/MCPChartServer) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@wubbyweb/MCPChartServer">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@wubbyweb/MCPChartServer/badge" alt="Chart Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.